### PR TITLE
ocp4_workload_cloud_architecture_workshop_webterminal_operator_namesp…

### DIFF
--- a/operator-setup/roles/ocp4_workload_connectivity_link/defaults/main.yml
+++ b/operator-setup/roles/ocp4_workload_connectivity_link/defaults/main.yml
@@ -191,7 +191,7 @@ ocp4_workload_connectivity_link_kuadrant_gitops_repo_path: platform/kuadrant
 # ------------------------------------------------
 
 ocp4_workload_connectivity_link_servicemesh_operator_application_name: servicemesh-operator
-ocp4_workload_connectivity_link_servicemesh_operator_application_namespace: gateway-system
+ocp4_workload_connectivity_link_servicemesh_operator_application_namespace: openshift-operators
 ocp4_workload_connectivity_link_servicemesh_operator_gitops_repo: "{{ ocp4_workload_connectivity_link_gitops_repo }}"
 ocp4_workload_connectivity_link_servicemesh_operator_gitops_repo_tag: main
 ocp4_workload_connectivity_link_servicemesh_operator_gitops_repo_path: platform/sail-operator


### PR DESCRIPTION
…ace: openshift-operators

ossm3 operator should be installed in the default namespace ocp4_workload_cloud_architecture_workshop_webterminal_operator_namespace: openshift-operators